### PR TITLE
feat: add tf-destroy workflow

### DIFF
--- a/.github/workflows/tf-destroy.yaml
+++ b/.github/workflows/tf-destroy.yaml
@@ -1,0 +1,38 @@
+name: Terraform Destroy
+
+on:
+  push:
+    branches: [ feat/destroy-workflow ]
+  workflow_dispatch:
+
+jobs:
+  terraform-destroy:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.12.0"
+      
+      - name: Terraform Init
+        run: terraform init
+        env:
+          AWS_ACCESS_KEY_ID: ${{ vars.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      
+      - name: Terraform Plan (Destroy)
+        run: terraform plan -destroy -out=destroy.tfplan
+        env:
+          AWS_ACCESS_KEY_ID: ${{ vars.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      
+      - name: Terraform Destroy
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: terraform apply destroy.tfplan
+        env:
+          AWS_ACCESS_KEY_ID: ${{ vars.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
# Add Terraform Destroy GitHub Action Workflow

## Overview
This PR adds a new GitHub Actions workflow that enables automated infrastructure teardown using Terraform. The workflow is triggered either by pushing to a specific branch or manually via the GitHub Actions UI.

## Changes
- Added `.github/workflows/tf-destroy.yml` to handle Terraform destroy operations
- Configured workflow to run on push to the `feat/destroy-workflow` branch and on manual workflow dispatch
- Included proper Terraform initialization and destroy planning steps

## Why
This workflow provides a controlled and automated way to tear down infrastructure when needed, which helps:
- Reduce manual effort during environment cleanup
- Prevent unnecessary cloud resource costs

## How to Use
You can trigger the Terraform destroy in two ways:
1. **Push to branch**: Push any commit to the `feat/destroy-workflow` branch to do the tf-plan only
2. **Manual trigger**: Go to the Actions tab in GitHub, select "Terraform Destroy" workflow, and click "Run workflow" to the main branch to really destroy the resources

## Security Considerations
- This workflow will destroy infrastructure without additional confirmation when triggered
