### PR TITLE
feat: access entries for root user

### DIFF
--- a/.github/workflows/tf-execution.yaml
+++ b/.github/workflows/tf-execution.yaml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   push:
     branches: [ main ]
+  workflow_dispatch:
 
 permissions:
   pull-requests: write
@@ -20,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,8 @@ data "aws_availability_zones" "available" {
   }
 }
 
+data "aws_caller_identity" "current" {}
+
 locals {
   cluster_name = "eks-testing-${random_string.suffix.result}"
 }
@@ -90,6 +92,13 @@ module "eks" {
       min_size     = 1
       max_size     = 2
       desired_size = 1
+    }
+  }
+  access_entries = {
+    root = {
+      kubernetes_groups = ["system:masters"]
+      principal_arn     = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+      type              = "STANDARD"
     }
   }
 }


### PR DESCRIPTION
# Add Root User Access to EKS Cluster

## Description
This PR adds an access entry for the AWS account's root user to the EKS cluster, granting admin permissions to access and manage resources within the cluster.

## Changes
- Added a data source to dynamically fetch the current AWS account ID
- Configured an access entry for the root user in the EKS module
- Assigned the root user to the `system:masters` Kubernetes group for admin privileges

## Motivation
The root user previously did not have explicit access to the EKS cluster resources. This change ensures that the root user can access and manage all Kubernetes resources, which is essential for administrative tasks and emergency access scenarios.

## Implementation Details
- Used the `access_entries` parameter in the EKS module to define the access policy
- Set the access type to `STANDARD` which is appropriate for IAM principals
- Configured the `system:masters` group membership to ensure the root user has full cluster admin privileges

## Security Considerations
While this change grants necessary administrative access, please note:
- Root user access should be used sparingly and only for critical administrative functions
- Ensure AWS root account has MFA enabled and follows security best practices